### PR TITLE
fix: avoid let usage

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -71,17 +71,16 @@ export const useSimplePagination = (
   const isMinimalCase = totalPages <= 1 || visibleButtons <= 1;
   const warnInfo = `Pagination: visibleButtons=${visibleButtons} is too small. Auto-adjusted to 5 for proper UX. Please use at least ${MIN_BTN} buttons.`;
 
+  let adjustedVisibleButtons = visibleButtons;
+
   if (isMinimalCase) return totalPages >= 1 ? [currentPage] : [];
 
   if (visibleButtons < MIN_BTN) {
     console.warn(warnInfo);
+    adjustedVisibleButtons = MIN_BTN;
   }
 
-  const adjustedVisibleButtons =
-    visibleButtons < MIN_BTN ? MIN_BTN : visibleButtons;
-
-  const excludedStatic =
-    Math.min(adjustedVisibleButtons, totalPages) - fixedButtons;
+  const excludedStatic = Math.min(adjustedVisibleButtons, totalPages) - fixedButtons;
   const length = Math.max(0, excludedStatic);
 
   const halfWindow = Math.floor(length / 2) + shift;

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,16 +71,17 @@ export const useSimplePagination = (
   const isMinimalCase = totalPages <= 1 || visibleButtons <= 1;
   const warnInfo = `Pagination: visibleButtons=${visibleButtons} is too small. Auto-adjusted to 5 for proper UX. Please use at least ${MIN_BTN} buttons.`;
 
-  let adjustedVisibleButtons = visibleButtons;
-
   if (isMinimalCase) return totalPages >= 1 ? [currentPage] : [];
 
   if (visibleButtons < MIN_BTN) {
     console.warn(warnInfo);
-    adjustedVisibleButtons = MIN_BTN;
   }
 
-  const excludedStatic = Math.min(adjustedVisibleButtons, totalPages) - fixedButtons;
+  const adjustedVisibleButtons =
+    visibleButtons < MIN_BTN ? MIN_BTN : visibleButtons;
+
+  const excludedStatic =
+    Math.min(adjustedVisibleButtons, totalPages) - fixedButtons;
   const length = Math.max(0, excludedStatic);
 
   const halfWindow = Math.floor(length / 2) + shift;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "ESNext",
-    "lib": ["ES2020"],
+    "lib": ["ES2020", "dom"],
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
Hi! 
I just found your repository on LinkedIn and decided to look at the code, and single thing that I'd fix - `let` keyword usage, as it seems to me less predictable. Of course, I asked GPT what we can improve also, but I wanted to help with my only ideas, so it up to you. 
Also, as you wrote in you readme "Type-safe — full TypeScript support included", I had the next error:
`Cannot find name 'console'. Do you need to change your target library? Try changing the 'lib' compiler option to include 'dom'.ts(2584)`.
Easiest fix I found - to add "dom" to `lib` array in `tsconfig.json`, so I've decided to commit it also.

